### PR TITLE
Merging with development to fix calculate_coverage error.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: nmecr
 Type: Package
 Title: An implementation of peer-reviewed energy data analysis algorithms for site-specific M&V
-Version: 1.0.13
+Version: 1.0.14
 Authors@R: c(person("Luu", "Dexter", email = "dluu@kw-engineering.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-1511-2561")),
 			 person("Johnson", "Devan", email = "djohnson@kw-engineering.com", role = c("ctb", "cph")),
 			 person("Jump", "David", email = "djump@kw-engineering.com", role = "cph"))

--- a/R/calculate_coverage.R
+++ b/R/calculate_coverage.R
@@ -158,7 +158,7 @@ calculate_coverage <- function(dataframe = NULL, ref_temp_data = NULL,
 
   if (dataframe_interval == "Monthly") {
     months_covered <- temp_coverage %>%
-      dplyr::filter(dplyr::between(bins, extrapolated_min_obs_OA_bin, extrapolated_max_obs_OA_bin))
+      dplyr::filter(dplyr::between(as.numeric(bins), extrapolated_min_obs_OA_bin, extrapolated_max_obs_OA_bin))
     
     months_covered <- min(sum(months_covered$n_ref_data), 12)
     
@@ -167,7 +167,7 @@ calculate_coverage <- function(dataframe = NULL, ref_temp_data = NULL,
     
   } else if (dataframe_interval == "Daily") {
     days_covered <- temp_coverage %>%
-      dplyr::filter(dplyr::between(bins, extrapolated_min_obs_OA_bin, extrapolated_max_obs_OA_bin))
+      dplyr::filter(dplyr::between(as.numeric(bins), extrapolated_min_obs_OA_bin, extrapolated_max_obs_OA_bin))
 
     days_covered <- min(sum(days_covered$n_ref_data), 365)
 
@@ -177,7 +177,7 @@ calculate_coverage <- function(dataframe = NULL, ref_temp_data = NULL,
   } else {
 
     hours_covered <- temp_coverage %>%
-      dplyr::filter(dplyr::between(bins, extrapolated_min_obs_OA_bin, extrapolated_max_obs_OA_bin))
+      dplyr::filter(dplyr::between(as.numeric(bins), extrapolated_min_obs_OA_bin, extrapolated_max_obs_OA_bin))
 
     hours_covered <- min(sum(hours_covered$n_ref_data), 8760)
 


### PR DESCRIPTION
Update `calculate_coverage` function to specify bins as numeric type. Fixes error introduced by newer version of dplyr. 