### PR TITLE
Expanded aggregate functionality

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: nmecr
 Type: Package
 Title: An implementation of peer-reviewed energy data analysis algorithms for site-specific M&V
-Version: 1.0.14
+Version: 1.0.1499
 Authors@R: c(person("Luu", "Dexter", email = "dluu@kw-engineering.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-1511-2561")),
 			 person("Johnson", "Devan", email = "djohnson@kw-engineering.com", role = c("ctb", "cph")),
 			 person("Jump", "David", email = "djump@kw-engineering.com", role = "cph"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,9 +2,14 @@ Package: nmecr
 Type: Package
 Title: An implementation of peer-reviewed energy data analysis algorithms for site-specific M&V
 Version: 1.0.15
-Authors@R: c(person("Luu", "Dexter", email = "dluu@kw-engineering.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-1511-2561")),
-			 person("Johnson", "Devan", email = "djohnson@kw-engineering.com", role = c("ctb", "cph")),
-			 person("Jump", "David", email = "djump@kw-engineering.com", role = "cph"))
+Authors@R: c(
+  person("Jacoby", "Maggie", email = "mjacoby@kw-engineering.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-9394-5393")),
+  person("Johnson", "Devan", email = "djohnson@kw-engineering.com", role = c("ctb", "cph"), comment = c(ORCID = "0000-0002-4566-4308")),
+  person("Jump", "David", email = "djump@kw-engineering.com", role = "cph"), comment = c(ORCID = "0000-0002-5014-8789")),
+  person("Luu", "Dexter", email = "dluu@kw-engineering.com", role = c("aut", "cre")),
+  person("Sharma", "Mrinalini", role = c("ctb"), comment = c(ORCID = "0000-0002-1511-2561")),
+  person("Wolfe", "Kyle", role = "ctb"))
+
 Description: nmecr builds statistical energy data models and provides a comprehensive assessment of model fit and prediction accuracy.
   It provides the complete portfolio of the industry standard energy data modeling algorithms and includes an enhancement that allows 
   data modeling of energy profiles with distinct energy use regimens for improved predictive accuracy. 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: nmecr
 Type: Package
 Title: An implementation of peer-reviewed energy data analysis algorithms for site-specific M&V
-Version: 1.0.1499
+Version: 1.0.15
 Authors@R: c(person("Luu", "Dexter", email = "dluu@kw-engineering.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-1511-2561")),
 			 person("Johnson", "Devan", email = "djohnson@kw-engineering.com", role = c("ctb", "cph")),
 			 person("Jump", "David", email = "djump@kw-engineering.com", role = "cph"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,6 @@ Imports:
     segmented,
     magrittr,
     assertive,
-    xts,
     zoo,
     purrr,
     stats,

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -35,6 +35,15 @@ aggregate <- function(eload_data = NULL, temp_data = NULL, additional_independen
     
   }
   
+  # Find interval of energy data
+  if(! is.null(eload_data)){
+    
+    nterval_eload <- diff(eload_data$time) %>%
+      stats::median(na.rm = T) %>%
+      lubridate::as.duration()
+    
+  }
+  
   # Store variable names to filter columns. Also grab the sequence of important indices
   if(! is.null(additional_independent_variables)) {
     
@@ -188,6 +197,9 @@ aggregate <- function(eload_data = NULL, temp_data = NULL, additional_independen
       dplyr::summarize("temp" = mean(temp, na.rm = T)) #%>%
     #stats::na.omit()
     
+    # Consider making the HDD and CDD calcs a function
+    
+    # Heating and cooling degree day calculations
     base_temp <- rep(temp_balancepoint, length(daily_temp$time))
     HDD <- base_temp - daily_temp$temp
     HDD[HDD < 0 ] <- 0
@@ -196,7 +208,8 @@ aggregate <- function(eload_data = NULL, temp_data = NULL, additional_independen
     
     daily_data <- dplyr::bind_cols(daily_temp, "HDD" = HDD, "CDD" = CDD)
     
-    if (is.null (eload_data)){
+    # Default case for if there is no eload data provided or the interval is more granular than monthly
+    if (is.null (eload_data) | (!is.null(eload_data) & nterval_eload < lubridate::as.duration("28 days"))){
       monthly_temp <- daily_data %>%
         dplyr::mutate(month = lubridate::floor_date(daily_data$time, "month")) %>%
         dplyr::group_by("time" = month) %>%
@@ -210,79 +223,129 @@ aggregate <- function(eload_data = NULL, temp_data = NULL, additional_independen
         dplyr::mutate(CDD_perday = CDD / days) #%>%
       #stats::na.omit()
       
-    } else if (! is.null(eload_data)) {
-      
-      nterval_eload <- stats::median(diff(as.numeric(eload_data$time)))/60
-      
-      if(nterval_eload < 40320) {
+      # Aggregate additional independent variables
+      if (! is.null(additional_independent_variables)){
         
-        monthly_temp <- daily_data %>%
-          dplyr::mutate(month = lubridate::floor_date(daily_data$time, "month")) %>%
+        monthly_additional_independent_variables <- additional_independent_variables %>%
+          dplyr::mutate(month = lubridate::floor_date(additional_independent_variables$time, "month")) %>%
           dplyr::group_by("time" = month) %>%
-          dplyr::summarize("temp" = mean(temp, na.rm = T),
-                           "HDD" = sum(HDD, na.rm = T),
-                           "CDD" = sum(CDD, na.rm = T))
+          dplyr::summarize_at(.vars = additional_variable_names,
+                              .funs = additional_variable_aggregation,
+                              na.rm = T)
         
-        monthly_temp <- monthly_temp %>%
-          dplyr::mutate(days = lubridate::days_in_month(monthly_temp$time)) %>%
-          dplyr::mutate(HDD_perday = HDD / days) %>%
-          dplyr::mutate(CDD_perday = CDD / days) #%>%
-        #stats::na.omit()
+        # Set column names and delete extraneous columns created by the summarize_at function
+        base::names(monthly_additional_independent_variables)[additional_variable_aggregation_indices] <- additional_variable_names
+        monthly_additional_independent_variables <- monthly_additional_independent_variables[, c("time", additional_variable_names)]
         
-      } else {
+        # Normalize additional variables by days in month
+        normalized_monthly_additional_independent_variables <- monthly_additional_independent_variables %>%
+          dplyr::mutate(across(-time, ~./monthly_temp$days))
         
-        monthly_temp <- data.frame("time" = eload_data$time)
+        base::names(normalized_monthly_additional_independent_variables)[-1] <- paste0(names(monthly_additional_independent_variables)[-1], "_perday")
         
-        monthly_temp <- data.frame(matrix(ncol = 5, nrow = length(eload_data$time)))
-        names(monthly_temp) <- c("time", "temp", "HDD", "CDD", "days")
-        monthly_temp$time <- eload_data$time
+        # Add on the normalized variables to the dataframe
+        monthly_additional_independent_variables <- monthly_additional_independent_variables %>%
+          dplyr::bind_cols(normalized_monthly_additional_independent_variables[-1])
         
-        for (i in 2:length(eload_data$time)) {
-          monthly_temp$temp[i] <- daily_data %>%
-            dplyr::filter(time >= monthly_temp$time[i] & time < monthly_temp$time[i+1]) %>%
-            dplyr::summarize("temp" = round(mean(temp),2)) %>%
-            as.numeric()
-          
-          monthly_temp$HDD[i] <- daily_data %>%
-            dplyr::filter(time >= monthly_temp$time[i] & time < monthly_temp$time[i+1]) %>%
-            dplyr::summarize("HDD" = round(sum(HDD),2)) %>%
-            as.numeric
-          
-          monthly_temp$CDD[i] <- daily_data %>%
-            dplyr::filter(time >= monthly_temp$time[i] & time < monthly_temp$time[i+1]) %>%
-            dplyr::summarize("CDD" = round(sum(CDD),2)) %>%
-            as.numeric()
-          
-          monthly_temp$days[i] <- difftime(monthly_temp$time[i+1], monthly_temp$time[i], units = "days") %>%
-            as.numeric()
-        }
-        
-        monthly_temp <- monthly_temp[stats::complete.cases(monthly_temp), ] %>%
-          dplyr::mutate(HDD_perday = HDD / days) %>%
-          dplyr::mutate(CDD_perday = CDD / days)
       }
+      
     }
-    if(! is.null(eload_data)) {
+    
+    if(! is.null(eload_data)){
       
-      nterval_eload <- stats::median(diff(as.numeric(eload_data$time)))/60
-      
-      if(nterval_eload < 40320) { # using 28 days
+      # When eload data is shorter than monthly
+      if (nterval_eload < lubridate::as.duration("28 days")){
         
         monthly_eload <- eload_data %>%
           dplyr::mutate(month = lubridate::floor_date(eload_data$time, "month")) %>%
           dplyr::group_by("time" = month) %>%
-          dplyr::summarize("eload" = sum(eload, na.rm = T)) #%>%
-        #stats::na.omit()
+          dplyr::summarize("eload" = sum(eload, na.rm = T))
         
+        # When eload data is at intervals longer than 28 days (could be monthly or longer)
       } else {
         
         monthly_eload <- eload_data
+        
+        # Create a data frame of time intervals and group numbers for each energy usage period
+        eload_intervals <- data.frame(
+          groupnum = seq(1, length(eload_data$time)-1),
+          interval_start = eload_data$time[-length(eload_data$time)],
+          interval_end = eload_data$time[-1])
+        
+        # Summarize temperature data by each period of the eload data
+        monthly_temp <- daily_data %>%
+          fuzzyjoin::fuzzy_inner_join(
+            eload_intervals,
+            by = c("time" = "interval_start", "time" = "interval_end"),
+            match_fun = list(`>=`, `<`)) %>%
+          dplyr::group_by(groupnum) %>%
+          dplyr::summarize("temp" = mean(temp, na.rm = T),
+                           "HDD" = sum(HDD, na.rm = T),
+                           "CDD" = sum(CDD, na.rm = T))
+        
+        # Add timestamps as start of each interval
+        colnames(monthly_temp)[1] <- "time"
+        monthly_temp$time <- eload_intervals$interval_start
+        
+        # Calculate degree days per days in month
+        monthly_temp$days <- as.numeric(diff(eload_data$time))
+        
+        monthly_temp <- monthly_temp[stats::complete.cases(monthly_temp), ] %>%
+          dplyr::mutate(HDD_perday = HDD / days) %>%
+          dplyr::mutate(CDD_perday = CDD / days) #%>%
+        #stats::na.omit()
+        
+        if(! is.null(additional_independent_variables)){
+          
+          monthly_additional_independent_variables <- additional_independent_variables %>%
+            fuzzyjoin::fuzzy_inner_join(
+              eload_intervals,
+              by = c("time" = "interval_start", "time" = "interval_end"),
+              match_fun = list(`>=`, `<`)) %>%
+            dplyr::group_by(groupnum) %>%
+            dplyr::summarize_at(.vars = additional_variable_names,
+                                .funs = additional_variable_aggregation,
+                                na.rm = T)
+          
+          colnames(monthly_additional_independent_variables)[1] <- "time"
+          monthly_additional_independent_variables$time <- eload_intervals$interval_start
+          
+          # Set column names and delete extraneous columns created by the summarize_at function
+          base::names(monthly_additional_independent_variables)[additional_variable_aggregation_indices] <- additional_variable_names
+          monthly_additional_independent_variables <- monthly_additional_independent_variables[, c("time", additional_variable_names)]
+          
+          # Normalize additional variables by days in month
+          normalized_monthly_additional_independent_variables <- monthly_additional_independent_variables %>%
+            dplyr::mutate(across(-time, ~./monthly_temp$days))
+          
+          base::names(normalized_monthly_additional_independent_variables)[-1] <- paste0(names(monthly_additional_independent_variables)[-1], "_perday")
+          
+          # Add on the normalized variables to the dataframe
+          monthly_additional_independent_variables <- monthly_additional_independent_variables %>%
+            dplyr::bind_cols(normalized_monthly_additional_independent_variables[-1])
+          
+        }
+        
       }
+      
+    }
+    
+    
+    # Joining and returning data
+    if(! is.null(eload_data)) {
       
       aggregated_data <- monthly_temp %>%
         dplyr::full_join(monthly_eload, by = "time") %>%
         dplyr::mutate(eload_perday = eload/days) %>%
         dplyr::distinct()
+      
+      if(! is.null(additional_independent_variables)) {
+        
+        aggregated_data <- aggregated_data %>%
+          dplyr::full_join(monthly_additional_independent_variables, by = "time") %>%
+          dplyr::distinct()
+        
+      }
       
       return(aggregated_data)
       

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -1,7 +1,9 @@
 #' Aggregate energy consumption and temperature data. Can be used to aggregate temperature data only as well.
 #'
-#' \code{Aggregate energy consumption and temperature data to hourly, daily, or monthly data intervals.
-#' This function uses dplyr for aggregation as opposed to xts. As a result, the timestamps are not shifted after aggregation.}
+#' \code{Aggregate energy consumption, temperature, and additional independent variable data to 15-minute, hourly, daily, or monthly data intervals.
+#' This function uses dplyr for aggregation and defaults to not time shifting data. If you believe your temperature data is time stamped on an
+#' end of period reporting convention (such as TMY data that begins at 1 am meaning 00:00 - 01:00) then set the shift_normal_weather = TRUE to shift
+#' the weather data backwards by one interval to match eload data.}
 #'
 #' @param eload_data A dataframe with energy consumption time series. Column names: "time" and "eload". Allowed time intervals: less-than 60-mins, hourly, daily, monthly
 #' @param temp_data A dataframe with weather time series. Column names: "time" and "temp". Allowed time intervals: less-than 60-mins, hourly, daily
@@ -19,7 +21,8 @@
 #' the function will choose a start date based on the latest beginning time stamp of all dataframes.
 #' @param end_date A POSIXct indicating the inclusive ending datetime to trim observations of all dataframes to end at. The timezone should match
 #' the timezone used in the time columns of all dataframes and the start_date argument (if provided). If the end_date argument is not provided, the
-#' function will choose an end date based on the earliest ending time stamp of all dataframes.
+#' function will choose an end date based on the earliest ending time stamp of all dataframes. When providing monthly energy usage data, the end_date
+#' parameter can be used to specify the end of the final usage period. Otherwise, the function will attempt 
 #'
 #' @importFrom magrittr %>%
 #'

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -337,7 +337,7 @@ aggregate <- function(eload_data = NULL, temp_data = NULL, additional_independen
         # Create a dataframe displaying the start and end dates for each usage interval
         eload_intervals <- data.frame(
           interval_start = monthly_eload$time,
-          interval_end = monthly_eload$time %m+% months(1)) # shift one month forward
+          interval_end = monthly_eload$time %m+% months(1) - lubridate::as.duration("1 day")) # shift one month forward
         
         # When eload data is at intervals longer than 28 days (could be monthly or longer)
       } else {

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -14,10 +14,10 @@
 #' @param shift_normal_weather A logical indicating whether or not to shift the weather data from end of period reporting to beginning of period reporting.
 #' This option is set to false by default, but if the user knows that the rest of their data, such as energy use, reports with timestamps at the beginning of each usage
 #' period, setting this option to true will align the weather to the beginning of the period as well.
-#' @param start_date A POSIXct indicating the starting datetime to trim observations of all dataframes to start at. The timezone should
+#' @param start_date A POSIXct indicating the inclusive starting datetime to trim observations of all dataframes to start at. The timezone should
 #' match the timezone used in the time columns of all dataframes and the end_date argument (if provided). If the start_date argument is not provided,
 #' the function will choose a start date based on the latest beginning time stamp of all dataframes.
-#' @param end_date A POSIXct indicating the ending datetime to trim observations of all dataframes to end at. The timezone should match
+#' @param end_date A POSIXct indicating the inclusive ending datetime to trim observations of all dataframes to end at. The timezone should match
 #' the timezone used in the time columns of all dataframes and the start_date argument (if provided). If the end_date argument is not provided, the
 #' function will choose an end date based on the earliest ending time stamp of all dataframes.
 #'
@@ -92,15 +92,15 @@ aggregate <- function(eload_data = NULL, temp_data = NULL, additional_independen
       purrr::compact() # Remove any NULL items from the list
     
     end_date <- min(Reduce(c, last_dates), na.rm = T)
-  }
-  
-  # If eload is the earliest ending dataframe, then extend the end_date by its interval
-  # so that other variables can be aggregated to the final usage period. This is particularly
-  # relevant for monthly data
-  if (! is.null(eload_data)){
-    # Read this logic as: if the last date of eload is less than all other last dates
-    if(all(last_dates$eload < within(last_dates, rm(eload)))) {
-      end_date <- end_date + nterval_eload
+    
+    # If eload is the earliest ending dataframe, then extend the end_date by its interval
+    # so that other variables can be aggregated to the final usage period. This is particularly
+    # relevant for monthly data
+    if (! is.null(eload_data)){
+      # Read this logic as: if the last date of eload is less than all other last dates
+      if(all(last_dates$eload < within(last_dates, rm(eload)))) {
+        end_date <- end_date + nterval_eload
+      }
     }
   }
   
@@ -129,7 +129,7 @@ aggregate <- function(eload_data = NULL, temp_data = NULL, additional_independen
     
     # Aggregation to 15-minute (quarterly) temperature data
     quarterly_temp <- temp_data %>%
-      dplyr::mutate(quarter = lubridate::floor_date(temp_data$time, "15 mins")) %>%
+      dplyr::mutate(quarter = lubridate::floor_date(time, "15 mins")) %>%
       dplyr::group_by("time" = quarter) %>%
       dplyr::summarize("temp" = mean(temp, na.rm = T)) #%>%
     #stats::na.omit()
@@ -138,7 +138,7 @@ aggregate <- function(eload_data = NULL, temp_data = NULL, additional_independen
     if(! is.null(eload_data)) {
       
       quarterly_eload <- eload_data %>%
-        dplyr::mutate(quarter = lubridate::floor_date(eload_data$time, "15 mins")) %>%
+        dplyr::mutate(quarter = lubridate::floor_date(time, "15 mins")) %>%
         dplyr::group_by("time" = quarter) %>%
         dplyr::summarize("eload" = sum(eload, na.rm = T)) #%>%
       #stats::na.omit()
@@ -149,7 +149,7 @@ aggregate <- function(eload_data = NULL, temp_data = NULL, additional_independen
     if(! is.null(additional_independent_variables)) {
       
       quarterly_additional_independent_variables <- additional_independent_variables %>%
-        dplyr::mutate(quarter = lubridate::floor_date(additional_independent_variables$time, "15 mins")) %>%
+        dplyr::mutate(quarter = lubridate::floor_date(time, "15 mins")) %>%
         dplyr::group_by("time" = quarter) %>%
         dplyr::summarize_at(.vars = additional_variable_names,
                             .funs = additional_variable_aggregation,
@@ -190,7 +190,7 @@ aggregate <- function(eload_data = NULL, temp_data = NULL, additional_independen
     
     # Aggregation to hourly temperature data
     hourly_temp <- temp_data %>%
-      dplyr::mutate(hour = lubridate::floor_date(temp_data$time, "hour")) %>%
+      dplyr::mutate(hour = lubridate::floor_date(time, "hour")) %>%
       dplyr::group_by("time" = hour) %>%
       dplyr::summarize("temp" = mean(temp, na.rm = T)) #%>%
     #stats::na.omit()
@@ -199,7 +199,7 @@ aggregate <- function(eload_data = NULL, temp_data = NULL, additional_independen
     if(! is.null(eload_data)) {
       
       hourly_eload <- eload_data %>%
-        dplyr::mutate(hour = lubridate::floor_date(eload_data$time, "hour")) %>%
+        dplyr::mutate(hour = lubridate::floor_date(time, "hour")) %>%
         dplyr::group_by("time" = hour) %>%
         dplyr::summarize("eload" = sum(eload, na.rm = T)) #%>%
       #stats::na.omit()
@@ -210,7 +210,7 @@ aggregate <- function(eload_data = NULL, temp_data = NULL, additional_independen
     if(! is.null(additional_independent_variables)) {
       
       hourly_additional_independent_variables <- additional_independent_variables %>%
-        dplyr::mutate(hour = lubridate::floor_date(additional_independent_variables$time, "hour")) %>%
+        dplyr::mutate(hour = lubridate::floor_date(time, "hour")) %>%
         dplyr::group_by("time" = hour) %>%
         dplyr::summarize_at(.vars = additional_variable_names,
                             .funs = additional_variable_aggregation,
@@ -252,7 +252,7 @@ aggregate <- function(eload_data = NULL, temp_data = NULL, additional_independen
     
     # Aggregation to daily temperature data
     daily_temp <- temp_data %>%
-      dplyr::mutate(day = lubridate::floor_date(temp_data$time, "day")) %>%
+      dplyr::mutate(day = lubridate::floor_date(time, "day")) %>%
       dplyr::group_by("time" = day) %>%
       dplyr::summarize("temp" = mean(temp, na.rm = T)) #%>%
     #stats::na.omit()
@@ -270,7 +270,7 @@ aggregate <- function(eload_data = NULL, temp_data = NULL, additional_independen
     if(! is.null(eload_data)) {
       
       daily_eload <- eload_data %>%
-        dplyr::mutate(day = lubridate::floor_date(eload_data$time, "day")) %>%
+        dplyr::mutate(day = lubridate::floor_date(time, "day")) %>%
         dplyr::group_by("time" = day) %>%
         dplyr::summarize("eload" = sum(eload, na.rm = T)) #%>%
       #stats::na.omit()
@@ -281,7 +281,7 @@ aggregate <- function(eload_data = NULL, temp_data = NULL, additional_independen
     if(! is.null(additional_independent_variables)) {
       
       daily_additional_independent_variables <- additional_independent_variables %>%
-        dplyr::mutate(day = lubridate::floor_date(additional_independent_variables$time, "day")) %>%
+        dplyr::mutate(day = lubridate::floor_date(time, "day")) %>%
         dplyr::group_by("time" = day) %>%
         dplyr::summarize_at(.vars = additional_variable_names,
                             .funs = additional_variable_aggregation,
@@ -321,7 +321,7 @@ aggregate <- function(eload_data = NULL, temp_data = NULL, additional_independen
   } else if (convert_to_data_interval == "Monthly"){
     
     daily_temp <- temp_data %>%
-      dplyr::mutate(day = lubridate::floor_date(temp_data$time, "day")) %>%
+      dplyr::mutate(day = lubridate::floor_date(time, "day")) %>%
       dplyr::group_by("time" = day) %>%
       dplyr::summarize("temp" = mean(temp, na.rm = T)) #%>%
     #stats::na.omit()
@@ -337,180 +337,134 @@ aggregate <- function(eload_data = NULL, temp_data = NULL, additional_independen
     
     daily_data <- dplyr::bind_cols(daily_temp, "HDD" = HDD, "CDD" = CDD)
     
-    # Default case for if there is no eload data provided or the interval is more granular than monthly
-    if (is.null (eload_data) | (!is.null(eload_data) & nterval_eload < lubridate::as.duration("28 days"))){
-      monthly_temp <- daily_data %>%
-        dplyr::mutate(month = lubridate::floor_date(daily_data$time, "month")) %>%
-        dplyr::group_by("time" = month) %>%
-        dplyr::summarize("temp" = mean(temp, na.rm = T),
-                         "HDD" = sum(HDD, na.rm = T),
-                         "CDD" = sum(CDD, na.rm = T))
-      
-      monthly_temp <- monthly_temp %>%
-        dplyr::mutate(days = lubridate::days_in_month(monthly_temp$time))
-      # Fix the number of days in the first and last month (since data may begin
-      # and end mid-month)
-      monthly_temp$days[1] <- monthly_temp$days[1] - lubridate::mday(start_date) + 1
-      monthly_temp$days[length(monthly_temp$days)] <- mday(end_date)
-      monthly_temp <- monthly_temp %>%
-        dplyr::mutate(HDD_perday = HDD / days) %>%
-        dplyr::mutate(CDD_perday = CDD / days) #%>%
-      #stats::na.omit()
-      
-      # Fix the start date
-      monthly_temp$time[1] <- lubridate::floor_date(start_date, "day")
-      
-      
-      # Aggregate additional independent variables
-      if (! is.null(additional_independent_variables)){
-        
-        monthly_additional_independent_variables <- additional_independent_variables %>%
-          dplyr::mutate(month = lubridate::floor_date(additional_independent_variables$time, "month")) %>%
-          dplyr::group_by("time" = month) %>%
-          dplyr::summarize_at(.vars = additional_variable_names,
-                              .funs = additional_variable_aggregation,
-                              na.rm = T)
-        
-        # Set column names and delete extraneous columns created by the summarize_at function
-        base::names(monthly_additional_independent_variables)[additional_variable_aggregation_indices] <- additional_variable_names
-        monthly_additional_independent_variables <- monthly_additional_independent_variables[, c("time", additional_variable_names)]
-        
-        # Fix the start date
-        monthly_additional_independent_variables$time[1] <- lubridate::floor_date(start_date, "day")
-        
-        # Normalize additional variables by days in month
-        normalized_monthly_additional_independent_variables <- monthly_additional_independent_variables %>%
-          dplyr::mutate(across(-time, ~./monthly_temp$days, .names = "{col}_perday"), .keep = "unused")
-        
-        # Add on the normalized variables to the dataframe
-        monthly_additional_independent_variables <- monthly_additional_independent_variables %>%
-          dplyr::bind_cols(normalized_monthly_additional_independent_variables[-1])
-        
-      }
-      
-    }
+    # Create a time series of monthly usage intervals to aggregate data to.
+    # Keep the start and end dates in tact, but have all other intervals begin
+    # on the first of the month.
+    intervals <- seq.POSIXt(lubridate::floor_date(start_date, "month"), lubridate::floor_date(end_date, "month"), by = "month")
+    intervals[1] <- lubridate::floor_date(start_date, "day")
+    # If the end date does not end of the first of a month, then add on an extra element to the intervals vector. Because we will
+    # later subtract 1 day from these to make them inclusive date ranges, add 1 for now to compensate.
+    if (lubridate::mday(end_date) != 1) intervals <- append(intervals, floor_date(end_date, "day") + lubridate::as.duration("1 day"))
+    
+    monthly_intervals <- data.frame(groupnum = seq(1, length(intervals)-1),
+                                    interval_start = intervals[-length(intervals)],
+                                    interval_end = intervals[-1] - lubridate::as.duration("1 day"),
+                                    days = as.numeric(diff(intervals)))
     
     if(! is.null(eload_data)){
       
-      # Round eload interval to the nearest day
-      rounded_nterval_eload <- round(nterval_eload/lubridate::as.duration("1 day"))*lubridate::as.duration("1 day")
-      
-      # When eload data is shorter than monthly
-      if (nterval_eload < lubridate::as.duration("28 days")){
+      # If eload is at an interval of monthly or more, we'll have to reconstruct the usage intervals so that
+      # they line up with when energy was measured.
+      if(nterval_eload >= lubridate::as.duration("28 days")){
         
-        # Aggregate eload
-        monthly_eload <- eload_data %>%
-          dplyr::mutate(month = lubridate::floor_date(eload_data$time, "month")) %>%
-          dplyr::group_by("time" = month) %>%
-          dplyr::summarize("eload" = sum(eload, na.rm = T))
+        intervals <- eload_data$time %>%
+          lubridate::floor_date("day")
         
-        # Fix the start date
-        monthly_eload$time[1] <- lubridate::floor_date(start_date, "day")
-        
-        # Create a dataframe displaying the start and end dates for each usage interval
-        eload_intervals <- data.frame(
-          interval_start = monthly_eload$time,
-          interval_end = lubridate::floor_date(monthly_eload$time, "month") %m+% months(1) - lubridate::as.duration("1 day")) # shift one month forward
-        
-        # Fix the end date
-        eload_intervals$interval_end[length(eload_intervals$interval_end)] <- lubridate::floor_date(end_date, "day")
-        
-        # When eload data is at intervals longer than 28 days (could be monthly or longer)
-      } else {
-        
-        monthly_eload <- eload_data
-        
-        # Create a data frame of time intervals with inclusive start and end dates with
-        # corresponding group numbers for each energy usage period.
-        # For the final usage period, because no end date is provided, the duration is assumed
-        # to be the same as the median interval.
-        eload_intervals <- data.frame(
-          groupnum = seq(1, length(eload_data$time)),
-          interval_start = eload_data$time,
-          interval_end = append(eload_data$time[-1], tail(eload_data$time, n=1) + rounded_nterval_eload) - lubridate::as.duration("1 day"))
-        
-        # Summarize temperature data by each period of the eload data using an overlap join
-        monthly_temp <- daily_data %>%
-          dplyr::inner_join(
-            eload_intervals,
-            by = join_by("time" >= "interval_start", "time" <= "interval_end")) %>%
-          dplyr::group_by(groupnum) %>%
-          dplyr::summarize("temp" = mean(temp, na.rm = T),
-                           "HDD" = sum(HDD, na.rm = T),
-                           "CDD" = sum(CDD, na.rm = T))
-        
-        # Add timestamps as start of each interval
-        colnames(monthly_temp)[1] <- "time"
-        monthly_temp$time <- eload_intervals$interval_start
-        
-        # Create column for days in each usage period. For the final usage period, because
-        # an end date is not known, the number of days is assumed to be the median interval.
-        monthly_temp$days <- append(as.numeric(diff(eload_data$time)), rounded_nterval_eload/lubridate::as.duration("1 day"))
-        
-        monthly_temp <- monthly_temp[stats::complete.cases(monthly_temp), ] %>%
-          dplyr::mutate(HDD_perday = HDD / days) %>%
-          dplyr::mutate(CDD_perday = CDD / days) #%>%
-        #stats::na.omit()
-        
-        if(! is.null(additional_independent_variables)){
-          
-          # Summarize additional variables by each period of the eload data using an overlap join
-          monthly_additional_independent_variables <- additional_independent_variables %>%
-            dplyr::inner_join(
-              eload_intervals,
-              by = join_by("time" >= "interval_start", "time" <= "interval_end")) %>%
-            dplyr::group_by(groupnum) %>%
-            dplyr::summarize_at(.vars = additional_variable_names,
-                                .funs = additional_variable_aggregation,
-                                na.rm = T)
-          
-          # Add the time column back in place of the group number column
-          colnames(monthly_additional_independent_variables)[1] <- "time"
-          monthly_additional_independent_variables$time <- eload_intervals$interval_start
-          
-          # Set column names and delete extraneous columns created by the summarize_at function
-          base::names(monthly_additional_independent_variables)[additional_variable_aggregation_indices] <- additional_variable_names
-          monthly_additional_independent_variables <- monthly_additional_independent_variables[, c("time", additional_variable_names)]
-          
-          # Normalize additional variables by days in month
-          normalized_monthly_additional_independent_variables <- monthly_additional_independent_variables %>%
-            dplyr::mutate(across(-time, ~./monthly_temp$days, .names = "{col}_perday"), .keep = "unused")
-          
-          # Add on the normalized variables to the dataframe
-          monthly_additional_independent_variables <- monthly_additional_independent_variables %>%
-            dplyr::bind_cols(normalized_monthly_additional_independent_variables[-1])
-          
+        # Check if the end_date is beyond the end of the eload dataframe. When this is the case, add another
+        # date to the intervals.
+        # Also shift last date forward by 1 day to compensate for subtraction that will occur to all values in a few lines
+        if (tail(intervals, n=1) < lubridate::floor_date(end_date, "day")){
+          intervals <- append(intervals, floor_date(end_date, "day") + lubridate::as.duration("1 day"))
+        } else {
+          intervals[length(intervals)] <- tail(intervals, n=1) + lubridate::as.duration("1 day")
         }
         
+        monthly_intervals <- data.frame(groupnum = seq(1, length(intervals)-1),
+                                        interval_start = intervals[-length(intervals)],
+                                        interval_end = intervals[-1] - lubridate::as.duration("1 day"),
+                                        days = as.numeric(diff(intervals)))
+        
+        # Because eload is already at monthly+ intervals, no need to perform aggregation
+        monthly_eload <- eload_data
+        
+      } else{
+        # When eload is at less than monthly intervals, will need to aggregate up.
+        # Can use the same usage intervals calculated before this if block
+        monthly_eload <- eload_data %>%
+          mutate(time = lubridate::floor_date(time, "day")) %>%
+          dplyr::inner_join(
+            monthly_intervals,
+            by = join_by("time" >= "interval_start", "time" <= "interval_end")) %>%
+          dplyr::group_by(groupnum) %>%
+          dplyr::summarize("eload" = sum(eload, na.rm = T)) %>%
+          dplyr::rename(time = groupnum) %>%
+          dplyr::mutate(time = monthly_intervals$interval_start)
+        
       }
-      
     }
     
+    # Summarize temperature data by each usage period using an overlap join
+    monthly_temp <- daily_data %>%
+      dplyr::mutate(time = lubridate::floor_date(time, "day")) %>%
+      dplyr::inner_join(
+        monthly_intervals,
+        by = join_by("time" >= "interval_start", "time" <= "interval_end")) %>%
+      dplyr::group_by(groupnum) %>%
+      dplyr::summarize("temp" = mean(temp, na.rm = T),
+                       "HDD" = sum(HDD, na.rm = T),
+                       "CDD" = sum(CDD, na.rm = T)) %>%
+      dplyr::mutate(days = monthly_intervals$days) %>%
+      dplyr::rename(time = groupnum) %>%
+      dplyr::mutate(time = monthly_intervals$interval_start) %>%
+      dplyr::mutate(HDD_perday = HDD / days) %>%
+      dplyr::mutate(CDD_perday = CDD / days) #%>%
+    #stats::na.omit()
+    
+    if(! is.null(additional_independent_variables)){
+      
+      # Summarize additional variables by each period of the eload data using an overlap join
+      monthly_additional_independent_variables <- additional_independent_variables %>%
+        dplyr::mutate(time = lubridate::floor_date(time, "day")) %>%
+        dplyr::inner_join(
+          monthly_intervals,
+          by = join_by("time" >= "interval_start", "time" <= "interval_end")) %>%
+        dplyr::group_by(groupnum) %>%
+        dplyr::summarize_at(.vars = additional_variable_names,
+                            .funs = additional_variable_aggregation,
+                            na.rm = T)
+      
+      # Add the time column back in place of the group number column
+      colnames(monthly_additional_independent_variables)[1] <- "time"
+      monthly_additional_independent_variables$time <- monthly_intervals$interval_start
+      
+      # Set column names and delete extraneous columns created by the summarize_at function
+      base::names(monthly_additional_independent_variables)[additional_variable_aggregation_indices] <- additional_variable_names
+      monthly_additional_independent_variables <- monthly_additional_independent_variables[, c("time", additional_variable_names)]
+      
+      # Normalize additional variables by days in month
+      normalized_monthly_additional_independent_variables <- monthly_additional_independent_variables %>%
+        dplyr::mutate(across(-time, ~./monthly_temp$days, .names = "{col}_perday"), .keep = "unused")
+      
+      # Add on the normalized variables to the dataframe
+      monthly_additional_independent_variables <- monthly_additional_independent_variables %>%
+        dplyr::bind_cols(normalized_monthly_additional_independent_variables[-1])
+      
+    }
     
     # Joining and returning data
+    
+    aggregated_data <- monthly_temp %>%
+      dplyr::mutate(interval_start = monthly_intervals$interval_start, .after = "time") %>%
+      dplyr::mutate(interval_end = monthly_intervals$interval_end, .after = "interval_start")
+    
     if(! is.null(eload_data)) {
       
-      aggregated_data <- monthly_temp %>%
+      aggregated_data <- aggregated_data %>%
         dplyr::full_join(monthly_eload, by = "time") %>%
         dplyr::mutate(eload_perday = eload/days) %>%
-        dplyr::mutate(interval_start = eload_intervals$interval_start, .after = "time") %>%
-        dplyr::mutate(interval_end = eload_intervals$interval_end, .after = "interval_start") %>%
         dplyr::distinct()
       
-      if(! is.null(additional_independent_variables)) {
-        
-        aggregated_data <- aggregated_data %>%
-          dplyr::full_join(monthly_additional_independent_variables, by = "time") %>%
-          dplyr::distinct()
-        
-      }
+    }
+    
+    if(! is.null(additional_independent_variables)) {
       
-      return(aggregated_data)
-      
-    } else {
-      
-      return(monthly_temp)
+      aggregated_data <- aggregated_data %>%
+        dplyr::full_join(monthly_additional_independent_variables, by = "time") %>%
+        dplyr::distinct()
       
     }
+    
+    return(aggregated_data)
+    
   }
 }

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -16,9 +16,22 @@
 #'
 
 aggregate <- function(eload_data = NULL, temp_data = NULL, convert_to_data_interval = c("Hourly", "Daily", "Monthly"),
-                      temp_balancepoint = 65) {
+                      temp_balancepoint = 65, shift_normal_weather = FALSE) {
 
   hour <- temp <- eload <- day <- month <- days <- time <- NULL # No visible binding for global variable
+  
+  # Shift temp data to beginning of period if shift flag is present
+  if(shift_normal_weather == TRUE) {
+    
+    if(! is.null(temp_data)){
+      
+      nterval_temp <- stats::median(diff(as.numeric(temp_data$time)))
+      temp_data <- temp_data %>%
+        dplyr::mutate(time = time - nterval_temp)
+      
+    }
+    
+  }
 
   if(convert_to_data_interval == "Hourly") {
 

--- a/R/create_dataframe.R
+++ b/R/create_dataframe.R
@@ -1,16 +1,24 @@
 #' Generate training or prediction dataframes.
 #'
-#' \code{This function creates a dataframe, combining eload, temp, and additional variable data.
-#'  It assumes that the input data is aligned to the start of a time period and outputs a dataframe that is also aligned to the start of time periods. }
+#' \code{This function creates a dataframe, combining eload, temp, and additional variable data. create_dataframe
+#'  is the user friendly wrapper for the aggregate function.By default, it assumes that the input data is aligned
+#'  to the start of a time period and outputs a dataframe that is also aligned to the start of time periods. In
+#'  cases where you are using normal weather data (such as TMY) that reports its timestamps at the end of each
+#'  period, then set shift_normal_weather = TRUE to shift the weather data backwards by one interval to match the
+#'  timestamp reporting convention for eload.}
 #'
-#' @param eload_data A dataframe with energy consumption time series. This dataframe should only be energy consumption data and not demand data. Column names: "time" and "eload". Allowed time intervals: 15-min, hourly, daily, monthly. The 'time' column must have Date-Time object values.
-#' @param temp_data A dataframe with weather time series. Column names: "time" and "temp". Allowed time intervals: 15-min, hourly, daily, monthly. The 'time' column must have Date-Time object values.
+#' @param eload_data A dataframe with energy consumption time series. This dataframe should only be energy consumption data and not demand data.
+#' Column names: "time" and "eload". Allowed time intervals: 15-min, hourly, daily, monthly. The 'time' column must have Date-Time object values.
+#' @param temp_data A dataframe with weather time series. Column names: "time" and "temp". Allowed time intervals: 15-min, hourly, daily, monthly.
+#' The 'time' column must have Date-Time object values.
 #' @param additional_independent_variables An optional dataframe for adding independent variables to the regression. This argument is a replacement for the older 'operating_mode_data' argument.
 #' @param additional_variable_aggregation A vector with aggregation functions for each of the variables in 'additional_independent_variables'.
 #' Usage example: c(sum, median) implies two additional independent variables. The first variable will be summed over the specified data interval
 #' and the median of the second variable will be taken over the specified data interval. Permissible aggregation functions: sum, mean, median
 #' @param start_date  A character string, of the format "mm/dd/yyyy hh:mm", indictating the inclusive start date and time of the intended dataframe
-#' @param end_date A character string, of the format "mm/dd/yyyy hh:mm", indictating the inclusive end date and time of the intended dataframe
+#' @param end_date A character string, of the format "mm/dd/yyyy hh:mm", indictating the inclusive end date and time of the intended dataframe.
+#' This parameter can also be used to specify the date for the end of the final reporting period for monthly energy usage data and aggregate 
+#' other data accordingly. Otherwise, the function will attempt to guess the end date for the final period to aggregate to.
 #' @param convert_to_data_interval A character string indicating the time interval to which the dataframe should be aggregated: '15-min', 'Hourly', 'Daily', and 'Monthly'
 #' @param temp_balancepoint A numeric indicating the balancepoint for the temp_data dataframe
 #' @param shift_normal_weather A logical indicating whether or not to shift the weather data from end of period reporting to beginning of period reporting.

--- a/R/create_dataframe.R
+++ b/R/create_dataframe.R
@@ -11,10 +11,13 @@
 #' @param additional_variable_aggregation A vector with aggregation functions for each of the variables in 'additional_independent_variables'.
 #' Usage example: c(sum, median) implies two additional independent variables. The first variable will be summed over the specified data interval
 #' and the median of the second variable will be taken over the specified data interval. Permissible aggregation functions: sum, mean, median
-#' @param start_date  A character string, of the format "mm/dd/yyyy hh:mm", indictating start date and time of the intended dataframe
-#' @param end_date A character string, of the format "mm/dd/yyyy hh:mm", indictating end date and time of the intended dataframe
+#' @param start_date  A character string, of the format "mm/dd/yyyy hh:mm", indictating the inclusive start date and time of the intended dataframe
+#' @param end_date A character string, of the format "mm/dd/yyyy hh:mm", indictating the inclusive end date and time of the intended dataframe
 #' @param convert_to_data_interval A character string indicating the time interval to which the dataframe should be aggregated: '15-min', 'Hourly', 'Daily', and 'Monthly'
 #' @param temp_balancepoint A numeric indicating the balancepoint for the temp_data dataframe
+#' @param shift_normal_weather A logical indicating whether or not to shift the weather data from end of period reporting to beginning of period reporting.
+#' This option is set to false by default, but if the user knows that the rest of their data, such as energy use, reports with timestamps at the beginning of each usage
+#' period, setting this option to true will align the weather to the beginning of the period as well.
 #'
 #' @importFrom stats median
 #' @importFrom magrittr %>%
@@ -23,9 +26,9 @@
 #' @export
 
 create_dataframe <- function(eload_data = NULL, temp_data = NULL, operating_mode_data = NULL,
-                             additional_independent_variables = NULL, additional_variable_aggregation = c(sum, median),
+                             additional_independent_variables = NULL, additional_variable_aggregation = c(sum, median, mean),
                              start_date = NULL, end_date = NULL,
-                             convert_to_data_interval = c("15-min", "Hourly", "Daily", "Monthly"), temp_balancepoint = 65) {
+                             convert_to_data_interval = c("15-min", "Hourly", "Daily", "Monthly"), temp_balancepoint = 65, shift_normal_weather = FALSE) {
 
   day <- temp <- time <- NULL # No visible binding for global variable
 
@@ -73,395 +76,81 @@ create_dataframe <- function(eload_data = NULL, temp_data = NULL, operating_mode
       stop("Enter the end date as a character string, preferably in the 'mm/dd/yyyy hh:mm' format")
     }
   }
-
-  # convert to xts objects ----
-
-  eload_data <- as.data.frame(eload_data)
-  temp_data <- as.data.frame(temp_data)
-  if(! is.null(additional_independent_variables)){
-    additional_independent_variables <- as.data.frame(additional_independent_variables)
+  
+  # Find intervals for each time series
+  if (! is.null(temp_data)) {
+    nterval_temp <- diff(temp_data$time) %>%
+      stats::median(na.rm = T) %>%
+      lubridate::as.duration()
   }
-
-  eload_data_xts <- xts::xts(x = eload_data[, -1], order.by = eload_data[, 1])
-  temp_data_xts <- xts::xts(x = temp_data[, -1], order.by = temp_data[, 1])
-  if(! is.null(additional_independent_variables)){
-    additional_independent_variables_xts <- xts::xts(x = additional_independent_variables[, -1], order.by = additional_independent_variables[, 1])
+  
+  if (! is.null(eload_data)) {
+    nterval_eload <- diff(eload_data$time) %>%
+      stats::median(na.rm = T) %>%
+      lubridate::as.duration()
   }
-
-  # Assigning column names  ----
-
-  colnames(eload_data_xts) <- "eload"
-  colnames(temp_data_xts) <- "temp"
-  if(! is.null(additional_independent_variables)){
-    additional_independent_variables_names <- colnames(additional_independent_variables)[-1]
-    colnames(additional_independent_variables_xts) <- additional_independent_variables_names
+  
+  if (! is.null(additional_independent_variables)) {
+    nterval_additional_independent_variables <- diff(additional_independent_variables$time) %>%
+      stats::median(na.rm = T) %>%
+      lubridate::as.duration()
   }
-
-  # Determine the input data interval and the aggregation interval based on them as well as based on the argument specification.  ----
-
-  # determine data intervals of eload, temp, and operating mode data
-  periodicity_eload <- xts::periodicity(eload_data_xts)
-  periodicity_temp <- xts::periodicity(temp_data_xts)
-  if(! is.null(additional_independent_variables)){
-    periodicity_additional_independent_variables <- xts::periodicity(additional_independent_variables_xts)
-  }
-
-  determine_data_interval_sec <- function(data_periodicity){ # determine the data interval in seconds
-
-    if(data_periodicity$scale == "minute"){
-      data_interval <- 60*data_periodicity$frequency
-    } else if (data_periodicity$scale == "hourly"){
-      data_interval <- 60*60
-    } else if (data_periodicity$scale == "daily"){
-      data_interval <- 60*60*24
-    } else if (data_periodicity$scale == "monthly"){
-      data_interval <- 60*60*24*mean(30,31)
-    }
-
-    return(data_interval)
-  }
-
-  # determine the data interval (in seconds) of eload, temp, and additional variable dataframes
-  eload_data_interval <- determine_data_interval_sec(periodicity_eload)
-  temp_data_interval <- determine_data_interval_sec(periodicity_temp)
-  if(! is.null(additional_independent_variables)){
-    additional_independent_variables_interval <- determine_data_interval_sec(periodicity_additional_independent_variables)
-  }
-
-  # determine the maximum data interval (in seconds) from the available dataframes
-  if(! is.null(additional_independent_variables)){
-    max_data_interval <- max(eload_data_interval, temp_data_interval, additional_independent_variables_interval)
-  } else {
-    max_data_interval <- max(eload_data_interval, temp_data_interval)
-  }
-
+  
+  # Find the max of all intervals
+  max_data_interval <- max(c(nterval_temp, nterval_eload, nterval_additional_independent_variables))
+  
   # assign modeling interval - based on either the user's input or max of uploaded datasets
   if (missing(convert_to_data_interval)) {
     nterval <- max_data_interval
   } else if(convert_to_data_interval == "15-min") {
-    if (max_data_interval > 60*15) {
+    if (max_data_interval > lubridate::as.duration("15 minutes")) {
       warning("Uploaded datasets have data intervals of greater than 15 minutes. Aggregating to the highest data interval.")
       nterval <- max_data_interval
     } else {
-      nterval <- 60*15
+      nterval <- lubridate::as.duration("15 minutes")
     }
   } else if(convert_to_data_interval == "Hourly") {
-    if (max_data_interval > 60*60) {
+    if (max_data_interval > lubridate::as.duration("1 hour")) {
       warning("Uploaded datasets have data intervals of greater than 1 hour. Aggregating to the highest data interval.")
       nterval <- max_data_interval
     } else {
-      nterval <- 60*60
+      nterval <- lubridate::as.duration("1 hour")
     }
   } else if (convert_to_data_interval == "Daily"){
-    if (max_data_interval > 60*60*24) {
+    if (max_data_interval > lubridate::as.duration("1 day")) {
       warning("Uploaded datasets have data intervals of greater than 1 day. Aggregating to the highest data interval.")
       nterval <- max_data_interval
     } else {
-      nterval <- 60*60*24
+      nterval <- lubridate::as.duration("1 day")
     }
   } else if (convert_to_data_interval == "Monthly") {
-      nterval <- 60*60*24*mean(30,31)
+      nterval <- lubridate::as.duration("1 month")
   } else {
     stop(paste0("Check spellings: convert_to_data_interval can be specified as one of the following:
                 '15-min', 'Hourly', 'Daily', or 'Monthly'."))
   }
 
-  # Set up for aggregating the additional independent variables  -----
-
-  if(! is.null(additional_independent_variables)) {
-
-    dfs <- list()
-    for (i in 1:length(additional_independent_variables_names)){
-      dfs[i] <- data.frame(additional_independent_variables[additional_independent_variables_names[i]])
-    }
-
-    names(dfs) <- additional_independent_variables_names
-
-    apply_aggregation <- function(df, aggregation_function, nterval){ # Function for aggregating individual columns of the additional_independent_variables input
-
-      if (nterval == 60*60){
-        xts_index <- "hours"
-      } else if (nterval == 60*60*24) {
-        xts_index <- "days"
-      } else if (nterval == 60*60*24*mean(30,31)) {
-        xts_index <- "months"
-      } else if (nterval == 60*15){
-        xts_index <- "min"
-      }
-
-      df <- data.frame(df)
-      df <- data.frame("time" = additional_independent_variables$time) %>%
-        dplyr::bind_cols(df)
-
-      df_xts <- xts::xts(x = df[, -1], order.by = df[, 1])
-
-      if(nterval == 60*60 | nterval == 60*60*24) { # hourly or daily
-
-        aggregated_df_xts <- xts::period.apply(df_xts, INDEX = xts::endpoints(df_xts, xts_index), FUN = aggregation_function, na.rm = T) %>%
-          xts::align.time(n = nterval)
-
-      } else if (nterval == 60*60*24*mean(30,31)) {
-
-        aggregated_df_xts <- xts::period.apply(df_xts, INDEX = xts::endpoints(df_xts, xts_index), FUN = aggregation_function, na.rm = T) %>%
-          xts::align.time(n = 60*additional_variable_alignment)
-
-      } else if (nterval == 60*15){
-
-        aggregated_df_xts <- xts::period.apply(df_xts, INDEX = xts::endpoints(df_xts, xts_index, k = 15), FUN = aggregation_function, na.rm = T) %>%
-          xts::align.time(n = nterval)
-      }
-
-      return(aggregated_df_xts)
-    }
+  # Assign string for interval
+  if (nterval == lubridate::as.duration("15 mins")) {
+    nterval_string <- "15-min"
+  } else if (nterval <= lubridate::as.duration("1 hour")){
+    nterval_string <- "Hourly"
+  } else if (nterval <= lubridate::as.duration("1 day")){
+    nterval_string <- "Daily"
+  } else {
+    nterval_string <- "Monthly"
   }
-
-  # Set up for aggregating the additional independent variables END -----
-
-  # Begin aggregation
-  if (nterval == 60*15) { # if the convert_to_data_interval input is '15-min' or max_data_interval (max interval based on input datasets) == 15 min
-
-    sum_eload_data_xts <- xts::period.apply(eload_data_xts$eload, INDEX = xts::endpoints(eload_data_xts, "mins", k = 15), FUN = sum, na.rm = T) %>%
-      xts::align.time(n = 60*15)
-
-    mean_temp_data_xts <- xts::period.apply(temp_data_xts$temp, INDEX = xts::endpoints(temp_data_xts, "mins", k = 15), FUN = mean, na.rm = T) %>%
-      xts::align.time(n = 60*15)
-
-    if(! is.null(additional_independent_variables)){
-
-      aggregated_dfs_xts <- purrr::map2(.x = dfs, .y = additional_variable_aggregation, .f = apply_aggregation, nterval = 60*15) # dfs calculated above
-
-      aggregated_df_xts <-  do.call('cbind', aggregated_dfs_xts)
-      names(aggregated_df_xts) <- additional_independent_variables_names
-
-      data_xts <- xts::merge.xts(sum_eload_data_xts, mean_temp_data_xts, aggregated_df_xts)
-
-    } else {
-
-      data_xts <- xts::merge.xts(sum_eload_data_xts, mean_temp_data_xts)
-
-    }
-
-
-  } else if (nterval == 60*60) { # if the convert_to_data_interval input is 'Hourly' or max_data_interval == 60*60
-
-    sum_eload_data_xts <- xts::period.apply(eload_data_xts$eload, INDEX = xts::endpoints(eload_data_xts, "hours"), FUN = sum, na.rm = T) %>%
-      xts::align.time(n = 60*60)
-
-    mean_temp_data_xts <- xts::period.apply(temp_data_xts$temp, INDEX = xts::endpoints(temp_data_xts, "hours"), FUN = mean, na.rm = T) %>%
-      xts::align.time(n = 60*60)
-
-
-    if(! is.null(additional_independent_variables)) {
-
-      aggregated_dfs_xts <- purrr::map2(.x = dfs, .y = additional_variable_aggregation, .f = apply_aggregation, nterval = 60*60) # dfs calculated above
-
-      aggregated_df_xts <-  do.call('cbind', aggregated_dfs_xts)
-      names(aggregated_df_xts) <- additional_independent_variables_names
-
-      data_xts <- xts::merge.xts(sum_eload_data_xts, mean_temp_data_xts, aggregated_df_xts)
-
-    } else {
-
-      data_xts <- xts::merge.xts(sum_eload_data_xts, mean_temp_data_xts)
-
-    }
-
-  } else if (nterval == 60*60*24) { # if the convert_to_data_interval input is 'Daily' or max_data_interval == 60*60*24. HDD and CDDs being calculated as well.
-
-    sum_eload_data_xts <- xts::period.apply(eload_data_xts$eload, INDEX = xts::endpoints(eload_data_xts, "days"), FUN = sum, na.rm = T) %>%
-      xts::align.time(n = 60*60*24)
-
-    mean_temp_data_xts <- xts::period.apply(temp_data_xts$temp, INDEX = xts::endpoints(temp_data_xts, "days"), FUN = mean, na.rm = T) %>%
-      xts::align.time(n = 60*60*24)
-
-    if(! is.null(additional_independent_variables)) {
-
-      aggregated_dfs_xts <- purrr::map2(.x = dfs, .y = additional_variable_aggregation, .f = apply_aggregation, nterval = 60*60*24)
-
-      aggregated_df_xts <-  do.call('cbind', aggregated_dfs_xts)
-      names(aggregated_df_xts) <- additional_independent_variables_names
-
-      data_xts <- xts::merge.xts(sum_eload_data_xts, mean_temp_data_xts, aggregated_df_xts)
-
-    } else {
-
-      data_xts <- xts::merge.xts(sum_eload_data_xts, mean_temp_data_xts)
-
-    }
-
-    data_xts$HDD <- temp_balancepoint - data_xts$temp
-    data_xts$HDD[data_xts$HDD < 0 ] <- 0
-    data_xts$CDD <- data_xts$temp - temp_balancepoint
-    data_xts$CDD[data_xts$CDD < 0 ] <- 0
-
-  } else if (nterval == 60*60*24*mean(30,31)) { # if the convert_to_data_interval input is 'Monthly'
-
-   determine_alignment <- function(nterval) {
-     if (nterval == 60*15 | nterval == 60*60) {
-       align_to_minutes <- 60 # aligning to 60 minutes because when aggregating to Monthly level, we want to get the rounded hour
-     } else if (nterval == 60*60*24){
-       align_to_minutes <- 60*24
-     }
-     else {
-       align_to_minutes <- NULL
-     }
-   }
-
-   eload_alignment <- determine_alignment(eload_data_interval)
-   temp_alignment <- determine_alignment(temp_data_interval)
-   if(! is.null(additional_independent_variables)) {
-     additional_variable_alignment <- determine_alignment(additional_independent_variables_interval)
-   }
-
-   if(! is.null(eload_alignment)) { # aggregate up if less than monthly
-     sum_eload_data_xts <- xts::period.apply(eload_data_xts$eload, INDEX = xts::endpoints(eload_data_xts, "months"), FUN = sum, na.rm = T) %>%
-       xts::align.time(n = 60*eload_alignment)
-   } else {
-     sum_eload_data_xts <- eload_data_xts # if input as monthly - assumption is that the its aligned to the end of the period
-   }
-
-   if(! is.null(temp_alignment)){ # aggregate up if less than monthly
-
-     daily_temp <- temp_data %>%
-       dplyr::mutate(day = lubridate::floor_date(temp_data$time, "day")) %>%
-       dplyr::group_by("time" = day) %>%
-       dplyr::summarize("temp" = mean(temp, na.rm = T)) %>%
-       stats::na.omit()
-
-     base_temp <- rep(temp_balancepoint, length(daily_temp$time))
-     HDD <- base_temp - daily_temp$temp
-     HDD[HDD < 0 ] <- 0
-     CDD <- daily_temp$temp - base_temp
-     CDD[CDD < 0 ] <- 0
-
-     daily_data <- dplyr::bind_cols(daily_temp, "HDD" = HDD, "CDD" = CDD)
-
-     monthly_temp <- data.frame(matrix(ncol = 5, nrow = length(sum_eload_data_xts)))
-     names(monthly_temp) <- c("time", "temp", "HDD", "CDD", "days")
-     monthly_temp$time <- zoo::index(sum_eload_data_xts)# aligning to eload - representing the end of the period
-
-     for (i in 2:length(monthly_temp$time)) {
-
-       monthly_temp$temp[i] <- daily_data %>%
-         dplyr::filter(time >= monthly_temp$time[i-1] & time < monthly_temp$time[i]) %>%
-         dplyr::summarize("temp" = round(mean(temp),2)) %>%
-         as.numeric()
-
-       monthly_temp$HDD[i] <- daily_data %>%
-         dplyr::filter(time >= monthly_temp$time[i-1] & time < monthly_temp$time[i]) %>%
-         dplyr::summarize("HDD" = round(sum(HDD),2)) %>%
-         as.numeric
-
-       monthly_temp$CDD[i] <- daily_data %>%
-         dplyr::filter(time >= monthly_temp$time[i-1] & time < monthly_temp$time[i]) %>%
-         dplyr::summarize("CDD" = round(sum(CDD),2)) %>%
-         as.numeric()
-
-       monthly_temp$days[i] <- difftime(monthly_temp$time[i], monthly_temp$time[i-1], units = "days") %>%
-         as.numeric()
-     }
-
-     # Fill in the first row
-     monthly_temp$temp[1] <- daily_data %>%
-       dplyr::filter(time >= monthly_temp$time[1] - 2592000 & time < monthly_temp$time[1]) %>%
-       dplyr::summarize("temp" = round(mean(temp),2)) %>%
-       as.numeric()
-
-     monthly_temp$HDD[1] <- daily_data %>%
-       dplyr::filter(time >= monthly_temp$time[1] - 2592000 & time < monthly_temp$time[1]) %>%
-       dplyr::summarize("HDD" = round(sum(HDD),2)) %>%
-       as.numeric
-
-     monthly_temp$CDD[1] <- daily_data %>%
-       dplyr::filter(time >= monthly_temp$time[1] - 2592000 & time < monthly_temp$time[1]) %>%
-       dplyr::summarize("CDD" = round(sum(CDD),2)) %>%
-       as.numeric()
-
-     monthly_temp$days[1] <- difftime(monthly_temp$time[1], monthly_temp$time[1] - 2592000, units = "days") %>%
-       as.numeric()
-
-     mean_temp_data_xts <-  xts::xts(x = monthly_temp[, -1], order.by = monthly_temp[, 1])
-
-   } else {
-
-      mean_temp_data_xts <- temp_data_xts # if input as monthly - assumption is that the its aligned to the end of the period
-      mean_temp_data_xts$days <- lubridate::days_in_month(lubridate::month(zoo::index(mean_temp_data_xts) - 30))
-      mean_temp_data_xts$HDD <- (temp_balancepoint - mean_temp_data_xts$temp)*mean_temp_data_xts$days
-      mean_temp_data_xts$HDD[mean_temp_data_xts$HDD < 0 ] <- 0
-      mean_temp_data_xts$CDD <- (mean_temp_data_xts$temp - temp_balancepoint)*mean_temp_data_xts$days
-      mean_temp_data_xts$CDD[mean_temp_data_xts$CDD < 0 ] <- 0
-
-   }
-
-
-   if(! is.null(additional_independent_variables)) {
-     if(! is.null(additional_variable_alignment)){ # aggregate up if less than monthly
-       aggregated_dfs_xts <- purrr::map2(.x = dfs, .y = additional_variable_aggregation, .f = apply_aggregation, nterval = 60*60*24*mean(30,31))
-       aggregated_df_xts <-  do.call('cbind', aggregated_dfs_xts)
-       names(aggregated_df_xts) <- additional_independent_variables_names
-     } else {
-       aggregated_df_xts <- additional_independent_variables_xts
-     }
-     data_xts <- xts::merge.xts(sum_eload_data_xts, mean_temp_data_xts, aggregated_df_xts)
-   } else {
-    data_xts <- xts::merge.xts(sum_eload_data_xts, mean_temp_data_xts)
-   }
-  }
-
-
-  # Filter dataframe based on start and end dates ----
-
-  if(! is.null(start_date)) {
-
-    check_start_date <- suppressWarnings(lubridate::mdy_hm(start_date))
-    if(is.na(check_start_date)) {
-      start_date <- paste(paste(lubridate::month(start_date), lubridate::day(start_date), lubridate::year(start_date), sep = "/"), paste(lubridate::hour(start_date), lubridate::minute(start_date), sep = ":"), sep = " ")
-    }
-    data_xts <- data_xts[zoo::index(data_xts) >= lubridate::mdy_hm(start_date)]
-  }
-
-  if(! is.null(end_date)) {
-
-    check_end_date <- suppressWarnings(lubridate::mdy_hm(end_date))
-    if(is.na(check_end_date)) {
-      end_date <- paste(paste(lubridate::month(end_date), lubridate::day(end_date), lubridate::year(end_date), sep = "/"), paste(lubridate::hour(end_date), lubridate::minute(end_date), sep = ":"), sep = " ")
-    }
-
-    data_xts <- data_xts[zoo::index(data_xts) <= lubridate::mdy_hm(end_date)]
-  }
-
-  df <- dplyr::as_tibble(cbind.data.frame(zoo::index(data_xts), zoo::coredata(data_xts)))
-  names(df)[1] = "time"
-
-  # Normalize df by number of days in period, if df is monthly
-
-  if (nterval == 2592000){
-
-    df_columns <- colnames(df)
-    remove <- c("time", "temp", "days")
-    df_columns <- df_columns[!df_columns %in% remove]
-
-    normalize_by_days <- function(df_col, days_col) {
-
-      if (nrow(unique(df_col)) <= 2) { # check if the column is categorical or numerical
-        normalized_df_col = df_col # and process accordingly
-      } else {
-        normalized_df_col = df_col/days_col
-      }
-    }
-
-    normalized_df <- data.frame(matrix(nrow = nrow(df), ncol = length(df_columns)))
-    names(normalized_df) <- paste0(df_columns, "_perday")
-
-    for (i in 1:length(df_columns)){
-      normalized_df[i] <- normalize_by_days(df_col = df[df_columns[i]], days_col = df$days)
-    }
-
-
-    df <- df %>%
-      dplyr::bind_cols(normalized_df)
-
-  }
+  
+  df <- aggregate(eload_data, temp_data, additional_independent_variables,
+                  additional_variable_aggregation,
+                  convert_to_data_interval = nterval_string,
+                  temp_balancepoint = temp_balancepoint, shift_normal_weather = shift_normal_weather)
+  
+  # Return only data within the start and end dates
+  df <- df %>%
+    dplyr::filter(time >= lubridate::mdy_hm(start_date),
+                  time <= lubridate::mdy_hm(end_date)
+  
 
   return(df)
 


### PR DESCRIPTION
The `aggregate` and `create_dataframe` functions have been re-written to accomplish these main tasks:

- Fix time shifting issues
- Remove dependence on the xts package
- Add support for additional independent variables to the aggregate function
- Increase performance
- Simplify the code, increase readability, and improve documentation
- Unify the procedures used for aggregation

Part of the procedure unification process involved stripping the primary processing code out of the `create_dataframe` function and instead calling to the `aggregate` function to serve as the processing engine. `create_dataframe` now acts as a user friendly front end function that will check and error trap inputs. `aggregate` can also be called directly by nmecr users, but its purpose is more intended to be an procedure that can be used within other functions and analysis scripts where the developer is certain that arguments are formatted correctly.