### PR TITLE
Savings uncertainty fix

### DIFF
--- a/R/calculate_savings_and_uncertainty.R
+++ b/R/calculate_savings_and_uncertainty.R
@@ -84,14 +84,13 @@ calculate_savings_and_uncertainty <- function(prediction_df = NULL, savings_frac
 
   } else if (modeled_object$model_input_options$chosen_modeling_interval == "Daily") {
 
-    observation_count <- length(modeled_object$training_data$time) %>%
-      magrittr::divide_by(mean(30, 31))
+    observation_count <- m/mean(c(30, 31))
 
     alpha <- ( - 0.00024 * (observation_count ^ 2) + (0.03535 * (observation_count) + 1.00286))
 
   } else if (modeled_object$model_input_options$chosen_modeling_interval == "Monthly") {
 
-    observation_count <- length(modeled_object$training_data$time)
+    observation_count <- m
 
     alpha <- (- 0.00022 * (observation_count ^ 2)) + (0.03306 * (observation_count)) + 0.94054
   }

--- a/R/normalized_savings_and_uncertainty.R
+++ b/R/normalized_savings_and_uncertainty.R
@@ -89,13 +89,13 @@ calculate_norm_savings_and_uncertainty <- function(baseline_model = NULL, baseli
 
   } else if (baseline_model$model_input_options$chosen_modeling_interval == "Daily") {
 
-    observation_count <- 12
+    observation_count <- nrow(normalized_weather)/mean(c(30, 31))
 
     alpha <- ( - 0.00024 * (observation_count ^ 2) + (0.03535 * (observation_count) + 1.00286))
 
   } else if (baseline_model$model_input_options$chosen_modeling_interval == "Monthly") {
 
-    observation_count <- 12
+    observation_count <- nrow(normalized_weather)
 
     alpha <- (- 0.00022 * (observation_count ^ 2)) + (0.03306 * (observation_count)) + 0.94054
   }


### PR DESCRIPTION
# Fixed issues with calculation of Sun & Balthazar polynomial by using the correct observation count. This issue would lead to a slight overestimation of FSU in some cases.

## Background

For Daily and Monthly models, `nmecr` replaces ASHRAE Guideline 14's constant `1.26` coefficient with the Sun & Balthazar (ASHRAE) correction polynomial `Y(M)`, where `M` is the period length in months. Per the paper, `M` is the **post-installation / savings-analysis period** (the variable swept in the paper's Figures 2–4), not the baseline length. The current code feeds the **baseline** training length into the polynomial, which biases the fractional savings uncertainty (FSU) whenever the reporting period differs from the baseline.

For the common case of a 1-year baseline forecast onto a shorter reporting period, the polynomial is evaluated at ~12 months instead of the true reporting length, applying a near-annual correction (`Y ≈ 1.3`) where a smaller one is warranted (`Y ≈ 1.13` at 6 months). Net effect: FSU is **overestimated proportionally by ~15%** for daily/monthly models — a conservative bias that can cause false threshold failures (e.g., the ≤50% rule). Hourly/15-min models are unaffected, since they use the flat `alpha = 1.26` with no polynomial.

## Changes

**`calculate_savings_and_uncertainty` (avoided use / actual savings)**

- The Sun & Balthazar polynomial now uses `m` (the reporting-period count) rather than the baseline training length. Because `m` is already defined upstream as `length(prediction_df$time)` when a prediction frame is supplied and falls back to `n` when it is not, the with/without-prediction cases are handled by a single code path with no extra branching.
- Fixed a latent divisor bug: `mean(30, 31)` → `mean(c(30, 31))`. The former passed `31` as the `trim` argument and returned `30`; the corrected form returns the intended `30.5` days/month. **Note:** this shifts all existing daily results by ~1.6%, independent of the observation-count fix.

**`calculate_norm_savings_and_uncertainty` (normalized savings)**

- Replaced the hardcoded `observation_count <- 12` with a count derived from the normalization period (`nrow(normalized_weather)`, expressed in months for Daily). This is the `g` (typical-year period) analog of `m` and is the correct argument for the polynomial in the normalized case.
- The division is safe at any input weather interval: `normalized_weather` is already re-aggregated to the model's interval near the top of the function, so an hourly weather frame supplied to a daily model is collapsed to daily rows before this block runs.
- Backward compatible for standard annual normalization (`g ≈ 12`), so existing results do not move; the change only matters for non-annual normalization periods.